### PR TITLE
fix(event_processor.go): existing-ip-annotion bug

### DIFF
--- a/internal/event_processor.go
+++ b/internal/event_processor.go
@@ -246,9 +246,6 @@ func (processor *EventProcessor) verifyIp(svc *v1.Service) (string, string, erro
 			return "", "", err
 		}
 	}
-	if svc.Annotations[ExistingIpAnnotation] != "" {
-		return "", "", err
-	}
 	if ip.Ip == "" {
 		ip, serverName, err := processor.createIp(svc)
 		if err != nil {


### PR DESCRIPTION
## Issue Description

When using the cloudscale-slb-controller together with the existing-ip annotation, we never get past the point where the IP is reassigned to the correct node. This happens if we do not use the annotation and let the controller create the ip.

Creation of IP by controller:

```
time="2022-02-11T14:41:08Z" level=debug msg="event implies that an ip needs to be created" event_type=ADDED service=default/nginx-deployment service_ip=
time="2022-02-11T14:41:08Z" level=debug msg="[createIp] default/nginx-deployment: getting target node for new floating ip"
time="2022-02-11T14:41:08Z" level=debug msg="[getFloatingIpTargetServerForNewIp] default/nginx-deployment: fetching endpoints"
time="2022-02-11T14:41:08Z" level=debug msg="[getFloatingIpTargetServerForNewIp] default/nginx-deployment: no endpoints object found; using node-0.example.com"
time="2022-02-11T14:41:08Z" level=debug msg="[CreateFloatingIp] creating floating ip on server xxx-xxx-xxx-xxx on cloudscale.ch"
time="2022-02-11T14:41:08Z" level=debug msg="[ListFloatingIps] listing floating ips on cloudscale.ch"
time="2022-02-11T14:41:08Z" level=debug msg="[CreateFloatingIp] calling cloudscale.ch API"
time="2022-02-11T14:41:11Z" level=info msg="ip address xxx.xxx.xxx.xxx for service default/nginx-deployment created successfully and attached to node-0.example.com"
time="2022-02-11T14:41:11Z" level=info msg="load balancer ingress for service default/nginx-deployment updated successfully and attached to node-0.example.com"
time="2022-02-11T14:41:11Z" level=debug msg="[GetFloatingIp] loading floating ip xxx.xxx.xxx.xxx on cloudscale.ch"
time="2022-02-11T14:41:11Z" level=debug msg="[verifyIp] default/nginx-deployment: checking if floating ip is attached to a node with a running pod"
time="2022-02-11T14:41:11Z" level=debug msg="[GetServerNameForServerId] returning server name node-0.example.com for server with id xxx-xxx-xxx-xxx"
time="2022-02-11T14:41:11Z" level=debug msg="[verifyIp] default/nginx-deployment: floating ip xxx.xxx.xxx.xxx is attached to node node-0.example.com"
time="2022-02-11T14:41:11Z" level=debug msg="[verifyIp] default/nginx-deployment: first node with ready pod is node-2.example.com"
time="2022-02-11T14:41:11Z" level=debug msg="[verifyIp] default/nginx-deployment: floating ip xxx.xxx.xxx.xxx not attached to a node with a running ready pod"
time="2022-02-11T14:41:11Z" level=debug msg="[verifyIp] default/nginx-deployment: looking up server id xxx-xxx-xxx-xxx node node-2.example.com"
time="2022-02-11T14:41:11Z" level=debug msg="[GetServerIdForNode] returning server id xxx-xxx-xxx-xxx for server with name node-2.example.com"
time="2022-02-11T14:41:11Z" level=debug msg="[verifyIp] default/nginx-deployment: re-attaching floating ip xxx.xxx.xxx.xxx to node-2.example.com"
time="2022-02-11T14:41:11Z" level=debug msg="[UpdateFloatingIp] updating floating ip xxx.xxx.xxx.xxx with new server id xxx-xxx-xxx-xxx on cloudscale.ch"
time="2022-02-11T14:41:13Z" level=info msg="successfully verified ip xxx.xxx.xxx.xxx for service default/nginx-deployment attached to node-2.example.com"
```

If using existing-ip annotation. Specially the lines 

```
time="2022-02-11T14:39:35Z" level=debug msg="[GetFloatingIp] loading floating ip xxx.xxx.xxx.xxx on cloudscale.ch"
time="2022-02-11T14:39:35Z" level=info msg="successfully verified ip xxx.xxx.xxx.xxx for service default/nginx-deployment attached to "
```

made as wondering, why it was finishing with `attached to"` and not continuing.

```
time="2022-02-11T14:16:22Z" level=debug msg="processing service on initial load" svc=infra-ingress/ingress-controller
time="2022-02-11T14:16:22Z" level=debug msg="[GetFloatingIp] loading floating ip xxx.xxx.xxx.xxx on cloudscale.ch"
time="2022-02-11T14:16:22Z" level=info msg="successfully verified ip xxx.xxx.xxx.xxx for service infra-ingress/ingress-controller attached to "
time="2022-02-11T14:16:22Z" level=debug msg="[DefaultRetryManager:Start] starting retry manager"
time="2022-02-11T14:39:34Z" level=debug msg="event implies that an ip needs to be created" event_type=ADDED service=default/nginx-deployment service_ip=
time="2022-02-11T14:39:34Z" level=debug msg="[createIp] default/nginx-deployment: getting target node for new floating ip"
time="2022-02-11T14:39:34Z" level=debug msg="[getFloatingIpTargetServerForNewIp] default/nginx-deployment: fetching endpoints"
time="2022-02-11T14:39:34Z" level=debug msg="[getFloatingIpTargetServerForNewIp] default/nginx-deployment: no endpoints object found; using node-0.example.com"
time="2022-02-11T14:39:34Z" level=debug msg="[GetFloatingIp] loading floating ip xxx.xxx.xxx.xxx on cloudscale.ch"
time="2022-02-11T14:39:34Z" level=info msg="ip address xxx.xxx.xxx.xxx for service default/nginx-deployment created successfully and attached to node-0.example.com"
time="2022-02-11T14:39:34Z" level=info msg="load balancer ingress for service default/nginx-deployment updated successfully and attached to node-0.example.com"
time="2022-02-11T14:39:34Z" level=debug msg="event implies that the service already has an ip" event_type=MODIFIED service=default/nginx-deployment service_ip=xxx.xxx.xxx.xxx
time="2022-02-11T14:39:34Z" level=debug msg="[GetFloatingIp] loading floating ip xxx.xxx.xxx.xxx on cloudscale.ch"
time="2022-02-11T14:39:34Z" level=info msg="successfully verified ip xxx.xxx.xxx.xxx for service default/nginx-deployment attached to "
time="2022-02-11T14:39:34Z" level=debug msg="[GetFloatingIp] loading floating ip xxx.xxx.xxx.xxx on cloudscale.ch"
time="2022-02-11T14:39:34Z" level=info msg="successfully verified ip xxx.xxx.xxx.xxx for service default/nginx-deployment attached to "
time="2022-02-11T14:39:35Z" level=debug msg="[GetFloatingIp] loading floating ip xxx.xxx.xxx.xxx on cloudscale.ch"
time="2022-02-11T14:39:35Z" level=info msg="successfully verified ip xxx.xxx.xxx.xxx for service default/nginx-deployment attached to "
```

## Solution

We analyzed the code and found out, that verifyIp() was never being called to attach the Floating IP to the correct node. 

We gave it a try by removing line `250-253` from `event_processor.go`, build the container image on `adfinissygroup/cloudscale-slb-controller:dev` and tried it out on a cluster.

This worked like a charm, and the Floating IP was being allocated on the correct node and also switching it in case the respective endpoint was starting somewhere else.

Can you please look at this, also why this piece of code was inside the function? Special reason for it? 

Regards -- Adfinis

Thanks to @isantospardo for the help debugging this!

---
Signed-off-by: Toni Tauro <toni.tauro@adfinis.com>
